### PR TITLE
Update default Python version from 2.7 to 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN groupadd -g $groupid $username && \
     echo "$username ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     echo $username >/root/username
 
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.6 2
+
 ENV HOME=/home/$username
 ENV USER=$username
 WORKDIR /source


### PR DESCRIPTION
Up-to-date 'repo' command no longer supports Python versions 2.x.
For example, Python v2.x does not support the `rb""` syntax
in `re.compile(rb"^ *#")` used by `repo'.